### PR TITLE
feat: Rename action `actionConstant` to `actionType`

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ A very easy to understand and use set of tools for Redux. Includes:
 ### Actions
 
 Actions are built using a namespace and an object of "payload creators". The
-property names are considered the action constants.
+property names are considered the action types.
 
 A payload creator is a function that takes any number of arguments and returns
 what will be the action's payload (or, if you'd prefer, you can return both a
@@ -30,10 +30,9 @@ export default createActions('example', {
   // An action with an argument that also returns a payload.
   setIncrementBy: (n: number) => n,
 
-  // An action that returns meta, payload, and even overrides the action
-  // constant.
-  // Note that when you override the action constant, the `.actionConstant`
-  // property will be inconsistent.
+  // An action that returns meta, payload, and even overrides the action type.
+  // Note that when you override the action type, the `.actionType` property
+  // will be inconsistent.
   safeSetIncrementBy: (n: number) => ({
     type: 'example/setIncrementBy',
     payload: n > 10 ? 10 : n,
@@ -267,7 +266,7 @@ cleanup.
 import { reduxActionSideEffect } from 'redux-easy-mode'
 
 reduxActionSideEffect(actions.increment, ({ action, dispatch, getState }) => {
-  console.log(`${actions.increment.actionConstant} was dispatched`)
+  console.log(`${actions.increment.actionType} was dispatched`)
 
   // Return a function if you'd like to do some cleanup before this function is
   // called again.

--- a/src/createActions.test.ts
+++ b/src/createActions.test.ts
@@ -2,7 +2,7 @@ import testActions from './test/testActions'
 
 describe('createActions', () => {
   it('supports no arguments / payload', () => {
-    expect(testActions.noPayload.actionConstant).toEqual('test/noPayload')
+    expect(testActions.noPayload.actionType).toEqual('test/noPayload')
     expect(testActions.noPayload()).toEqual({
       type: 'test/noPayload',
       payload: undefined,
@@ -10,9 +10,7 @@ describe('createActions', () => {
   })
 
   it('supports returning a payload', () => {
-    expect(testActions.simplePayload.actionConstant).toEqual(
-      'test/simplePayload',
-    )
+    expect(testActions.simplePayload.actionType).toEqual('test/simplePayload')
     expect(testActions.simplePayload()).toEqual({
       type: 'test/simplePayload',
       payload: 'simple',
@@ -20,9 +18,7 @@ describe('createActions', () => {
   })
 
   it('supports any number of arguments', () => {
-    expect(testActions.complexPayload.actionConstant).toEqual(
-      'test/complexPayload',
-    )
+    expect(testActions.complexPayload.actionType).toEqual('test/complexPayload')
     expect(testActions.complexPayload(42, 'foo')).toEqual({
       type: 'test/complexPayload',
       payload: {
@@ -33,7 +29,7 @@ describe('createActions', () => {
   })
 
   it('supports special properties like type, meta, and payload', () => {
-    expect(testActions.specialProperties.actionConstant).toEqual(
+    expect(testActions.specialProperties.actionType).toEqual(
       'test/specialProperties',
     )
     expect(testActions.specialProperties(42, 'foo')).toEqual({
@@ -48,10 +44,10 @@ describe('createActions', () => {
       },
     })
 
-    expect(testActions.overriddenActionConstant.actionConstant).toEqual(
-      'test/overriddenActionConstant',
+    expect(testActions.overriddenActionType.actionType).toEqual(
+      'test/overriddenActionType',
     )
-    expect(testActions.overriddenActionConstant()).toEqual({
+    expect(testActions.overriddenActionType()).toEqual({
       type: 'totally overridden',
       payload: '',
     })

--- a/src/createActions.ts
+++ b/src/createActions.ts
@@ -21,7 +21,7 @@ export interface ReduxActionCreator<
   (...args: Parameters<PayloadCreator>): {
     type: `${Namespace}/${ActionType}`
   } & PayloadAndMeta<PayloadCreator>
-  actionConstant: `${Namespace}/${ActionType}`
+  actionType: `${Namespace}/${ActionType}`
 }
 
 type PayloadAndMeta<
@@ -70,7 +70,7 @@ function createActions<
       // attributes in one go.
     }) as any
 
-    actionCreators[key].actionConstant = `${namespace}/${key}`
+    actionCreators[key].actionType = `${namespace}/${key}`
   }
 
   return actionCreators

--- a/src/createReducer.ts
+++ b/src/createReducer.ts
@@ -31,10 +31,10 @@ interface ReduxReducerBuilder<State> {
 }
 
 interface AddHandler<State> {
-  // Handler that takes a string constant. Here it's up to the user to giver a
+  // Handler that takes a string action type. Here it's up to the user to give a
   // type for the action.
   <A extends Action>(
-    actionConstant: string,
+    actionType: string,
     handler: ReduxReducerCaseHandler<State, A>,
   ): ReduxReducerBuilder<State>
 
@@ -62,22 +62,22 @@ function createReducer<State>(
       handler: ReduxReducerCaseHandler<State, Action>,
     ) => {
       if (isReduxActionCreator(actionCreator)) {
-        handlers[actionCreator.actionConstant] = handler
+        handlers[actionCreator.actionType] = handler
       } else {
         handlers[actionCreator] = handler
       }
       return builder
     },
     addStartHandler: (actionCreator, handler) => {
-      handlers[startActionType(actionCreator.actionConstant)] = handler as any
+      handlers[startActionType(actionCreator.actionType)] = handler as any
       return builder
     },
     addSuccessHandler: (actionCreator, handler) => {
-      handlers[successActionType(actionCreator.actionConstant)] = handler as any
+      handlers[successActionType(actionCreator.actionType)] = handler as any
       return builder
     },
     addErrorHandler: (actionCreator, handler) => {
-      handlers[errorActionType(actionCreator.actionConstant)] = handler as any
+      handlers[errorActionType(actionCreator.actionType)] = handler as any
       return builder
     },
   }

--- a/src/isReduxActionCreator.ts
+++ b/src/isReduxActionCreator.ts
@@ -1,7 +1,7 @@
 import { ReduxActionCreator } from 'createActions'
 
 function isReduxActionCreator(arg: any): arg is ReduxActionCreator {
-  return !!arg?.actionConstant
+  return !!arg?.actionType
 }
 
 export default isReduxActionCreator

--- a/src/sideEffects/reduxActionSideEffect.ts
+++ b/src/sideEffects/reduxActionSideEffect.ts
@@ -8,10 +8,10 @@ interface ReduxActionSideEffectHandler<Action> {
 }
 
 interface ReduxActionSideEffect {
-  // Handler that takes a string constant. Here it's up to the user to giver a
+  // Handler that takes a string action type. Here it's up to the user to give a
   // type for the action.
   <A extends Action>(
-    actionConstant: string,
+    actionType: string,
     handler: ReduxActionSideEffectHandler<A>,
   ): void | (() => void)
 
@@ -35,9 +35,7 @@ const reduxActionSideEffect: ReduxActionSideEffect = (
   action: ReduxActionCreator | string,
   handler: ReduxActionSideEffectHandler<Action>,
 ) => {
-  const actionType = isReduxActionCreator(action)
-    ? action.actionConstant
-    : action
+  const actionType = isReduxActionCreator(action) ? action.actionType : action
 
   if (!actionSideEffects[actionType]) {
     actionSideEffects[actionType] = []

--- a/src/test/testActions.ts
+++ b/src/test/testActions.ts
@@ -8,7 +8,7 @@ const testActions = createActions('test', {
     payload: { arg1, arg2 },
     meta: { arg1: `meta ${arg1}`, arg2: `meta ${arg2}` },
   }),
-  overriddenActionConstant: () => ({
+  overriddenActionType: () => ({
     type: 'totally overridden',
     payload: '',
   }),


### PR DESCRIPTION
It's the more-correct term.