### PR TITLE
feat: New side effect interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,7 +265,7 @@ cleanup.
 ```ts
 import { reduxActionSideEffect } from 'redux-easy-mode'
 
-reduxActionSideEffect(actions.increment, ({ action, dispatch, getState }) => {
+reduxActionSideEffect(actions.increment, (action, dispatch, getState) => {
   console.log(`${actions.increment.actionType} was dispatched`)
 
   // Return a function if you'd like to do some cleanup before this function is
@@ -287,12 +287,12 @@ import { reduxSelectorSideEffect } from 'redux-easy-mode'
 
 reduxSelectorSideEffect(
   (state: RootState) => state.some.value,
-  ({ value, previousValue, dispatch, getState }) => {
+  (value, previousValue, dispatch, getState) => {
     console.log('value:', value)
     console.log('previousValue:', previousValue)
 
-    // Return a function if you'd like to do some cleanup before this function is
-    // called again.
+    // Return a function if you'd like to do some cleanup before this function
+    // is called again.
     return () => {
       console.log('cleanup')
     }

--- a/src/sideEffects/reduxActionSideEffect.test.ts
+++ b/src/sideEffects/reduxActionSideEffect.test.ts
@@ -12,7 +12,7 @@ describe('reduxActionSideEffect', () => {
 
     reduxActionSideEffect(
       testActions.simplePayload,
-      ({ action, getState, dispatch }) => {
+      (action, dispatch, getState) => {
         actionPayload = action.payload
         getState()
         dispatch({ type: '' })

--- a/src/sideEffects/reduxActionSideEffect.ts
+++ b/src/sideEffects/reduxActionSideEffect.ts
@@ -4,7 +4,7 @@ import { Action, Dispatch, MiddlewareAPI } from 'redux'
 import isReduxActionCreator from '../isReduxActionCreator'
 
 interface ReduxActionSideEffectHandler<Action> {
-  (config: { action: Action; dispatch: Dispatch; getState: () => any }): void
+  (action: Action, dispatch: Dispatch, getState: () => any): void
 }
 
 interface ReduxActionSideEffect {
@@ -51,31 +51,20 @@ export async function runActionSideEffects(
   store: MiddlewareAPI,
 ) {
   if (actionSideEffects[action.type]) {
-    for (const wut of actionSideEffects[action.type]) {
+    for (const sideEffect of actionSideEffects[action.type]) {
       try {
-        wut.cleanup?.()
+        sideEffect.cleanup?.()
       } catch (err) {
         console.error(err)
       }
 
-      const maybeCleanupFunction = wut.handler({
+      const maybeCleanupFunction = sideEffect.handler(
         action,
-        dispatch: store.dispatch,
-        getState: store.getState,
-      })
+        store.dispatch,
+        store.getState,
+      )
 
-      wut.cleanup = maybeCleanupFunction
+      sideEffect.cleanup = maybeCleanupFunction
     }
   }
 }
-
-// const actions = createActions('sideEffects', {
-//   test: () => ({ foo: 'bar' }),
-// })
-
-// reduxActionSideEffect(
-//   actions.test.actionConstant,
-//   (action: ReturnType<typeof actions.test>, dispatch, getState) => {},
-// )
-
-// reduxActionSideEffect(actions.test, (action, dispatch, getState) => {})

--- a/src/sideEffects/reduxSelectorSideEffect.test.ts
+++ b/src/sideEffects/reduxSelectorSideEffect.test.ts
@@ -1,6 +1,5 @@
 import reduxSelectorSideEffect, {
   runSelectorSideEffects,
-  UNSET_PREVIOUS_VALUE,
 } from './reduxSelectorSideEffect'
 
 interface State {
@@ -12,7 +11,7 @@ function createState(state: State) {
 }
 
 describe('reduxSelectorSideEffect', () => {
-  it('is called when the given type is dispatched', () => {
+  it('is called when the result of the selector changes', () => {
     const dispatch = jest.fn()
     const valueTest = jest.fn()
     const previousValueTest = jest.fn()
@@ -34,7 +33,7 @@ describe('reduxSelectorSideEffect', () => {
 
     expect(dispatch).toHaveBeenCalled()
     expect(valueTest).toHaveBeenLastCalledWith('bar')
-    expect(previousValueTest).toHaveBeenLastCalledWith(UNSET_PREVIOUS_VALUE)
+    expect(previousValueTest).toHaveBeenLastCalledWith(undefined)
 
     runSelectorSideEffects({
       dispatch,
@@ -70,7 +69,7 @@ describe('reduxSelectorSideEffect', () => {
 
     expect(dispatch).toHaveBeenCalled()
     expect(valueTest).toHaveBeenLastCalledWith('bar')
-    expect(previousValueTest).toHaveBeenLastCalledWith(UNSET_PREVIOUS_VALUE)
+    expect(previousValueTest).toHaveBeenLastCalledWith(undefined)
     expect(cleanup).not.toHaveBeenCalled()
 
     runSelectorSideEffects({

--- a/src/sideEffects/reduxSelectorSideEffect.test.ts
+++ b/src/sideEffects/reduxSelectorSideEffect.test.ts
@@ -19,7 +19,7 @@ describe('reduxSelectorSideEffect', () => {
 
     reduxSelectorSideEffect(
       (state: State) => state.foo,
-      ({ value, previousValue, getState, dispatch }) => {
+      (value, previousValue, dispatch, getState) => {
         valueTest(value)
         previousValueTest(previousValue)
         getState()
@@ -53,7 +53,7 @@ describe('reduxSelectorSideEffect', () => {
 
     reduxSelectorSideEffect(
       (state: State) => state.foo,
-      ({ value, previousValue, getState, dispatch }) => {
+      (value, previousValue, dispatch, getState) => {
         valueTest(value)
         previousValueTest(previousValue)
         getState()

--- a/src/sideEffects/reduxSelectorSideEffect.ts
+++ b/src/sideEffects/reduxSelectorSideEffect.ts
@@ -13,8 +13,6 @@ interface Comparator<T> {
   (a: T, b: T): boolean
 }
 
-export const UNSET_PREVIOUS_VALUE = Symbol()
-
 const selectorSideEffects: {
   handler: ReduxSelectorSideEffectHandler<any>
   previousValue: any
@@ -34,7 +32,7 @@ function reduxSelectorSideEffect<
   selectorSideEffects.push({
     handler,
     selector,
-    previousValue: UNSET_PREVIOUS_VALUE,
+    previousValue: undefined,
     compare: comparator ? comparator : (a, b) => a === b,
   })
 }


### PR DESCRIPTION
Passing a single object to each side effect handler is nice, but it makes it awkward for the developer to use their own types for `dispatch` and `getState` (where it's better DX for `action`, `value` and `previousValue` to be inferred).

Using `UNSET_PREVIOUS_VALUE` for the initial `previousValue` in selector side effects is technically more correct, but it really complicates things when developers are returning an object from a selector. IE what is now this ...

```ts
if (value.foo !== previousValue?.foo) {
}
```

... would have been ...

```ts
import {
  UNSET_PREVIOUS_VALUE,
} from 'redux-easy-mode/lib/sideEffects/reduxSelectorSideEffect'

if (
  previousValue !== UNSET_PREVIOUS_VALUE &&
  value.foo !== previousValue.foo
) {
}
```