### PR TITLE
fix: `"types"` in package

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "description": "",
   "main": "./lib/cjs/index.js",
   "module": "./lib/esm/index.mjs",
-  "types": "lib/index.d.ts",
+  "types": "./lib/cjs/index.d.ts",
   "exports": {
     ".": {
       "import": "./lib/esm/index.mjs",


### PR DESCRIPTION
Missed in https://github.com/mikew/redux-easy-mode/pull/7